### PR TITLE
Updated to SwiftNIO2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-	.package(url: "https://github.com/apple/swift-nio.git", from: "1.0.0")
+	.package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
Updated to Swift NIO2.  The most important change was changing some function labels from ctx: to context:.  That's not specified in the protocol so without that change it builds but receiving data silently fails.

I also added a comment showing how to chain two channel handlers in one spot with a flatmap.

Thank you for the Swift NIO example.  It was very helpful once I realized I needed to change ctx to context ;-)

- Darrell